### PR TITLE
14 typescript definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist
 node_modules
 npm-debug.log
 coverage

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,187 @@
+// Type definitions for Awilix v2.2.3
+// Project: https://github.com/jeffijoe/awilix
+// Definitions by: Brian Love <https://github.com/blove/>
+
+/**
+ * The container returned from createContainer has some methods and properties.
+ * @class AwilixContainer
+ */
+export declare class AwilixContainer {
+  createScope(): AwilixContainer;
+  loadModules(globPatterns: string[], options?: LoadModulesOptions): Module[];
+  registrations: Registration[];
+  register(name: string, registration: Registration): AwilixContainer;
+  register({ name: string, registration: Registration }): AwilixContainer;
+  registerClass<T>(name: string, instance: Object): AwilixContainer;
+  registerClass<T>(nameAndClassPair: RegisterNameAndClassPair<T>): AwilixContainer;
+  registerClass<T>(nameAndArrayClassPair: RegisterNameAndArrayClassPair<T>): AwilixContainer;
+  registerFunction(name: string, fn: Function): AwilixContainer;
+  registerFunction(nameAndFunctionPair: RegisterNameAndFunctionPair)
+  registerFunction(nameAndArrayPair: RegisterNameAndArrayFunctionPair): AwilixContainer;
+  registerValue(name: string, value: any): AwilixContainer;
+  registerValue(nameAndValuePairs: RegisterNameAndValuePair): AwilixContainer;
+  resolve<T>(name: string): T;
+}
+
+/**
+ * This is a special error thrown when Awilix is unable to resolve all dependencies
+ * (due to missing or cyclic dependencies).
+ * You can catch this error and use err instanceof AwilixResolutionError if you wish.
+ * It will tell you what dependencies it could not find or which ones caused a cycle.
+ * @class AwilixResolutionError
+ * @extends Error
+ */
+export declare class AwilixResolutionError extends Error {
+  //left blank intentionally
+}
+
+/**
+ * Creates a factory registration for classes that require `new`.
+ * @param {T} type
+ * @param {RegistrationOptions} options
+ * @return {Registration}
+ */
+export declare function asClass<T>(type: T, options?: RegistrationOptions): Registration;
+
+/**
+ * Creates a factory registration where the given factory function
+ * will be invoked with `new` when requested.
+ * @param {Function} fn
+ * @param {RegistrationOptions} options
+ * @return {Registration}
+ */
+export declare function asFunction(fn: Function, options?: RegistrationOptions): Registration;
+
+/**
+ * Creates a simple value registration where the given value will always be resolved.
+ * @param {any} value
+ * @param {RegistrationOptions} options
+ * @return {Registration}
+ */
+export declare function asValue(value: any, options?: RegistrationOptions): Registration;
+
+/**
+ * The options for the createContainer function.
+ * @interface ContainerOptions
+ */
+export interface ContainerOptions {
+  require?: (id: string) => any;
+}
+
+/**
+ * Creates an Awilix container instance.
+ * @param {ContainerOptions} options
+ * @return {AwilixContainer}
+ */
+export declare function createContainer(options?: ContainerOptions): AwilixContainer;
+
+/**
+ * Lifetime management.
+ * @class Lifetime
+ */
+export declare class Lifetime {
+  static SCOPED: string;
+  static SINGLETON: string;
+  static TRANSIENT: string;
+}
+
+/**
+ * Name formatting options when using loadModules().
+ * @type NameFormatters
+ */
+export type NameFormatters = "camelCase";
+
+/**
+ * Returns a promise for a list of {name, path} pairs,
+ * where the name is the module name, and path is the actual
+ * full path to the module.
+ * @param {string | string[]} globPatterns
+ * @param {ListModulesOptions} options
+ * @return Promise<Module[]>
+ */
+export declare function listModules(globPatterns?: string | string[], options?: ListModulesOptions): Promise<Module[]>;
+
+/**
+ * The options when invoking listModules().
+ * @interface ListModulesOptions
+ */
+export interface ListModulesOptions {
+  cwd?: string;
+}
+
+/**
+ * The options when invoking loadModules().
+ * @interface LoadModulesOptions
+ */
+export interface LoadModulesOptions {
+  cwd?: string;
+  formatName?: NameFormatters;
+  registrationOptions?: RegistrationOptions;
+}
+
+/**
+ * An object containing the module name and path (full path to module).
+ * @interface Module
+ */
+export interface Module {
+  name: string;
+  path: string;
+}
+
+/**
+ * Register a class using the [value, options] array syntax.
+ * @interface RegisterNameAndArrayClassPair<T>
+ */
+export interface RegisterNameAndArrayClassPair<T> {
+  [key: string]: [T, RegistrationOptions];
+}
+
+/**
+ * Register a function using the [value, options] array syntax.
+ * @interface RegisterNameAndArrayFunctionPair
+ */
+export interface RegisterNameAndArrayFunctionPair {
+  [key: string]: [Function, RegistrationOptions];
+}
+
+/**
+ * Register a class.
+ * @interface RegisterNameAndClassPair
+ */
+export interface RegisterNameAndClassPair<T> {
+  [key: string]: T;
+}
+
+/**
+ * Register a function.
+ * @interface RegisterNameAndFunctionPair
+ */
+export interface RegisterNameAndFunctionPair {
+  [key: string]: Function;
+}
+
+/**
+ * Register a value.
+ * @interface RegisterNameAndValuePair
+ */
+export interface RegisterNameAndValuePair {
+  [key: string]: any;
+}
+
+/**
+ * A registration object created by asClass(), asFunction() or asValue().
+ * @interface Registration
+ */
+export interface Registration {
+  singleton(): void;
+  scoped(): void;
+  transient(): void;
+}
+
+/**
+ * The options when registering a class, function or value.
+ * @interface RegistrationOptions
+ */
+export interface RegistrationOptions {
+  lifetime?: Lifetime;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ export declare function asFunction(fn: Function, options?: RegistrationOptions):
  * @param {RegistrationOptions} options
  * @return {Registration}
  */
-export declare function asValue(value: any, options?: RegistrationOptions): void;
+export declare function asValue(value: any, options?: RegistrationOptions): Registration;
 
 /**
  * The options for the createContainer function.
@@ -75,6 +75,16 @@ export interface ContainerOptions {
  * @return {AwilixContainer}
  */
 export declare function createContainer(options?: ContainerOptions): AwilixContainer;
+
+/**
+ * A registration object created by asClass() or asFunction().
+ * @interface FluidRegistration
+ */
+export interface FluidRegistration extends Registration {
+  singleton(): this;
+  scoped(): this;
+  transient(): this;
+}
 
 /**
  * Lifetime management.
@@ -178,13 +188,11 @@ export interface RegisterNameAndValuePair {
 }
 
 /**
- * A registration object created by asClass(), asFunction() or asValue().
- * @interface Registration
+ * A registration object returned by asClass(), asFunction() or asValue().
  */
 export interface Registration {
-  singleton(): this;
-  scoped(): this;
-  transient(): this;
+  resolve(): any;
+  lifetime: Lifetime;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -173,9 +173,9 @@ export interface RegisterNameAndValuePair {
  * @interface Registration
  */
 export interface Registration {
-  singleton(): Registration;
-  scoped(): Registration;
-  transient(): Registration;
+  singleton(): this;
+  scoped(): this;
+  transient(): this;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,12 +86,6 @@ export declare class Lifetime {
 }
 
 /**
- * Name formatting options when using loadModules().
- * @type NameFormatters
- */
-export type NameFormatters = "camelCase";
-
-/**
  * Returns a promise for a list of {name, path} pairs,
  * where the name is the module name, and path is the actual
  * full path to the module.
@@ -127,6 +121,12 @@ export interface Module {
   name: string;
   path: string;
 }
+
+/**
+ * Name formatting options when using loadModules().
+ * @type NameFormatters
+ */
+export type NameFormatters = "camelCase";
 
 /**
  * Register a class using the [value, options] array syntax.

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,9 +4,9 @@
 
 /**
  * The container returned from createContainer has some methods and properties.
- * @class AwilixContainer
+ * @interface AwilixContainer
  */
-export declare class AwilixContainer {
+export declare interface AwilixContainer {
   createScope(): AwilixContainer;
   loadModules(globPatterns: string[], options?: LoadModulesOptions): Module[];
   registrations: Registration[];
@@ -58,7 +58,7 @@ export declare function asFunction(fn: Function, options?: RegistrationOptions):
  * @param {RegistrationOptions} options
  * @return {Registration}
  */
-export declare function asValue(value: any, options?: RegistrationOptions): Registration;
+export declare function asValue(value: any, options?: RegistrationOptions): void;
 
 /**
  * The options for the createContainer function.
@@ -97,9 +97,9 @@ export type NameFormatters = "camelCase";
  * full path to the module.
  * @param {string | string[]} globPatterns
  * @param {ListModulesOptions} options
- * @return Promise<Module[]>
+ * @return Module[]
  */
-export declare function listModules(globPatterns?: string | string[], options?: ListModulesOptions): Promise<Module[]>;
+export declare function listModules(globPatterns?: string | string[], options?: ListModulesOptions): Module[];
 
 /**
  * The options when invoking listModules().
@@ -115,7 +115,7 @@ export interface ListModulesOptions {
  */
 export interface LoadModulesOptions {
   cwd?: string;
-  formatName?: NameFormatters;
+  formatName?: (fileName: string) => string | NameFormatters;
   registrationOptions?: RegistrationOptions;
 }
 
@@ -173,9 +173,9 @@ export interface RegisterNameAndValuePair {
  * @interface Registration
  */
 export interface Registration {
-  singleton(): void;
-  scoped(): void;
-  transient(): void;
+  singleton(): Registration;
+  scoped(): Registration;
+  transient(): Registration;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export declare class AwilixResolutionError extends Error {
  * @param {RegistrationOptions} options
  * @return {Registration}
  */
-export declare function asClass<T>(type: T, options?: RegistrationOptions): Registration;
+export declare function asClass<T>(type: T, options?: RegistrationOptions): FluidRegistration;
 
 /**
  * Creates a factory registration where the given factory function
@@ -51,7 +51,7 @@ export declare function asClass<T>(type: T, options?: RegistrationOptions): Regi
  * @param {RegistrationOptions} options
  * @return {Registration}
  */
-export declare function asFunction(fn: Function, options?: RegistrationOptions): Registration;
+export declare function asFunction(fn: Function, options?: RegistrationOptions): FluidRegistration;
 
 /**
  * Creates a simple value registration where the given value will always be resolved.

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare interface AwilixContainer {
   loadModules(globPatterns: string[], options?: LoadModulesOptions): Module[];
   registrations: Registration[];
   register(name: string, registration: Registration): AwilixContainer;
-  register({ name: string, registration: Registration }): AwilixContainer;
+  register(nameAndRegistrationPair: NameAndRegistrationPair): AwilixContainer;
   registerClass<T>(name: string, instance: Object): AwilixContainer;
   registerClass<T>(nameAndClassPair: RegisterNameAndClassPair<T>): AwilixContainer;
   registerClass<T>(nameAndArrayClassPair: RegisterNameAndArrayClassPair<T>): AwilixContainer;
@@ -93,7 +93,7 @@ export declare class Lifetime {
  * @param {ListModulesOptions} options
  * @return Module[]
  */
-export declare function listModules(globPatterns?: string | string[], options?: ListModulesOptions): Module[];
+export declare function listModules(globPatterns: string | string[], options?: ListModulesOptions): Module[];
 
 /**
  * The options when invoking listModules().
@@ -109,7 +109,7 @@ export interface ListModulesOptions {
  */
 export interface LoadModulesOptions {
   cwd?: string;
-  formatName?: (fileName: string) => string | NameFormatters;
+  formatName?: Function | NameFormatters;
   registrationOptions?: RegistrationOptions;
 }
 
@@ -120,6 +120,14 @@ export interface LoadModulesOptions {
 export interface Module {
   name: string;
   path: string;
+}
+
+/**
+ * Register a Registration
+ * @interface NameAndRegistrationPair
+ */
+export interface NameAndRegistrationPair {
+  [key: string]: Registration;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@
  * @interface AwilixContainer
  */
 export declare interface AwilixContainer {
+  cradle: { [key: string]: any };
   createScope(): AwilixContainer;
   loadModules(globPatterns: string[], options?: LoadModulesOptions): Module[];
   registrations: Registration[];

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "homepage": "https://github.com/jeffijoe/awilix#readme",
   "devDependencies": {
+    "@types/chai": "^3.4.35",
+    "@types/node": "^7.0.8",
     "chai": "^3.5.0",
     "coveralls": "^2.11.16",
     "eslint": "^3.15.0",
@@ -42,6 +44,7 @@
     "eslint-watch": "^2.1.14",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
+    "mocha-typescript": "^1.0.23",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   },

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,148 @@
+//import mocha and mocha-typescript
+import "mocha";
+import { suite, test } from "mocha-typescript";
+
+//require chai and use should assertions
+let chai = require("chai");
+chai.should();
+
+//import awilix definitions
+import {
+  asClass,
+  asFunction,
+  asValue,
+  createContainer,
+  AwilixContainer,
+  ContainerOptions,
+  Lifetime
+} from "../index";
+
+//import { createContainer } from "../lib/awilix";
+
+/**
+ * Test class for container.
+ * @class TestClass
+ */
+class TestClass { }
+
+/**
+ * Test function for container.
+ * @function testFunction
+ */
+function testFunction() { }
+
+/**
+ * Test value for container.
+ */
+const VALUE: string = "foo";
+
+/**
+ * Test the AwilixContainer class.
+ * @class TestAwilixContainer
+ */
+@suite
+class TestAwilixContainer {
+
+  private container: AwilixContainer;
+
+  /**
+   * Before each test hook.
+   * @method before
+   */
+  public beforeEach() {
+    //create container
+    this.container = createContainer();
+
+    //register tests
+    this.container.register({
+      testClass: asClass<TestClass>(TestClass),
+      testFunction: asFunction(testFunction),
+      testValue: asValue(VALUE)
+    });
+  }
+
+  /**
+   * Test the cradle proxy
+   * @method testCradle
+   */
+  @test("it should have a cradle proxy")
+  public testCradle() {
+    this.container.cradle.should.be.instanceOf(Proxy);
+    this.container.cradle.testClass.should.be.instanceOf(TestClass);
+    this.container.cradle.testFunction.should.be.a.function;
+    this.container.cradle.testValue.should.be.eql(VALUE);
+  }
+
+  @test("it should create a scope")
+  public testCreateScope() {
+    this.container.createScope();
+  }
+
+  @test("it should have at least one registration in the container")
+  public testRegistrations() {
+    this.container.registrations.should.be.an("array").with.lengthOf(3);
+  }
+
+  @test("it should register")
+  public testRegister() {
+    //single class
+    this.container.register("_testClass", asClass(TestClass));
+    let testClassReference = this.container.resolve<TestClass>("_testClass");
+    testClassReference.should.be.an.instanceOf(TestClass);
+
+    //single function
+    this.container.register("_testFunction", asFunction(testFunction));
+    let testFunctionReference = this.container.resolve<Function>("_testFunction");
+    testFunctionReference.should.be.a("function");
+
+    //single value
+    this.container.register("_testValue", asValue(VALUE));
+    let value = this.container.resolve("_testValue");
+    value.should.eql(VALUE);
+  }
+
+  @test("it should register a class")
+  public testRegisterClass() {
+    //single
+    this.container.registerClass("_testClass", TestClass);
+    let testClassReference = this.container.resolve<TestClass>("_testClass");
+    testClassReference.should.be.an.instanceOf(TestClass);
+
+    //name and value pair
+    this.container.registerClass<TestClass>({
+      "__testClass": TestClass
+    });
+    let testClassReference2 = this.container.resolve<TestClass>("__testClass");
+    testClassReference2.should.be.an.instanceOf(TestClass);
+  }
+
+  @test("it should register a function")
+  public testRegisterFunction() {
+    //single
+    this.container.registerFunction("_testFunction", testFunction);
+    let testFunctionReference = this.container.resolve("_testFunction");
+    testFunctionReference.should.be.a("function");
+
+    //name and value pair
+    this.container.registerFunction({
+      "__testFunction": testFunction
+    });
+    let testFunctionReference2 = this.container.resolve("__testFunction");
+    testFunctionReference2.should.be.a("function");
+  }
+
+  @test("it should register a value")
+  public testRegisterValue() {
+    //single
+    this.container.registerValue("_testValue", VALUE);
+    let value = this.container.resolve("_testValue");
+    value.should.eql(VALUE);
+
+    //name and value pair
+    this.container.registerValue({
+      "__testValue": VALUE
+    });
+    let value2 = this.container.resolve("__testValue");
+    value2.should.be.eql(VALUE);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "outDir": "dist",
+    "sourceMap": false,
+    "target": "es6"
+  },
+  "include": [
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "examples",
+    "lib",
+    "node_modules",
+    "**/.baseDir.ts"
+  ]
+}


### PR DESCRIPTION
* Added index.d.ts TypeScript definitions.
* Created test/index.ts to test the TypeScript definitions.
* Test is compiled to /dist.
* Added ignore or root /dist directory to .gitignore.
* You can execute the test by swapping out the definitions with the real thing.
* Created /tsconfig.json for compiling TypeScript definition file test.
* A successful compilation == passed test.
* Added dependencies for mocha, mocha-typescript and DefinitelyTyped definitions for chai and node.